### PR TITLE
Use docker/login-action for authentication

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -25,8 +25,10 @@ jobs:
         run: |
             python -m pip install -r requirements.txt
       - name: Authenticate with DockerHub
-        run: |
-            echo ${{ secrets.DOCKER_ACCESS_TOKEN }} | docker login -u ${{ secrets.DOCKER_USER }} --password-stdin
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USER }}
+          password: ${{ secrets.DOCKER_ACCESS_TOKEN }}
       - name: Run Pipeline
         run: |
             # Login


### PR DESCRIPTION
Uses [docker/login-action](https://github.com/marketplace/actions/docker-login) to authenticate with DockerHub in place of a shell command.